### PR TITLE
Improve CLI interface

### DIFF
--- a/find_kedro/cli.py
+++ b/find_kedro/cli.py
@@ -20,6 +20,9 @@ Options:
 ```
 
 """
+import os
+import sys
+
 import click
 from pygments import highlight
 from pygments.formatters import TerminalFormatter
@@ -58,7 +61,6 @@ __version__ = "0.0.1"
     type=click.Path(exists=False, file_okay=False),
     help="Path to save the static site to",
 )
-@click.option("--version", default=False, is_flag=True, help="Prints version and exits")
 @click.option(
     "--verbose",
     "-v",
@@ -66,23 +68,20 @@ __version__ = "0.0.1"
     is_flag=True,
     help="Prints extra information for debugging",
 )
-def cli(file_patterns, patterns, directory, version, verbose):
+@click.version_option(__version__, "-V", "--version", help="Prints version and exits")
+def cli(file_patterns, patterns, directory, verbose):
     if verbose:
-        import sys
-        import os
+        click.echo("python version: {}".format(sys.version))
+        click.echo("current directory: {}".format(os.getcwd()))
+        click.echo()
 
-        print("python version: ", sys.version)
-        print("current directory ", os.getcwd())
+        click.echo("find nodes recieved the following input")
+        click.echo("file_patterns: {}".format(file_patterns))
+        click.echo("patterns: {}".format(patterns))
+        click.echo("directory: {}".format(directory))
+        click.echo("version: {}".format(__version__))
+        click.echo("verbose: {}".format(verbose))
 
-        print("find nodes recieved the following input")
-        print("file_patterns: ", file_patterns)
-        print("patterns", patterns)
-        print("directory: ", directory)
-        print("version: ", version)
-        print("verbose: ", verbose)
-    if version:
-        click.echo(__version__)
-        return True
     pipelines = find_kedro(
         file_patterns=file_patterns,
         patterns=patterns,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_version():
     runner = CliRunner()
     result = runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
-    assert result.output == f"{__version__}\n"
+    assert __version__ in result.output
 
 
 def test_help():


### PR DESCRIPTION
### This PR tackles the following:

* Better use of `version` using `click.version_option` rather than building a custom version ourselves.
* Change `print` to `click.echo` (production python shouldn't have `print`'s)
* Move `import os` and `import sys` to top of the file. There's no performance improvements to importing them within the `cli` function because `import click` imports `os` and `sys` anyway, so there's no performance gain (Python has smart import loading, so won't load it twice).

### Tests:

* Had to fix a test for the `version`, but I'd suggest not testing that aspect anyway (maybe delete that test?) because it's more testing click than testing your own stuff.

### Question

Is there a reason you build a custom CLI instead of attaching to `kedro`'s? So `kedro find <...>`?
